### PR TITLE
fix(core): replace use-handle props with getters

### DIFF
--- a/src/core/hooks/use-field/use-field.ts
+++ b/src/core/hooks/use-field/use-field.ts
@@ -80,7 +80,9 @@ const createFieldHandle = <T, Err>(
 
     id: impl(descriptor).__path,
 
-    value: fieldState.val.value,
+    get value() {
+      return fieldState.val.value;
+    },
 
     get isTouched() {
       return (

--- a/src/core/hooks/use-form-handle/use-form-handle.ts
+++ b/src/core/hooks/use-form-handle/use-form-handle.ts
@@ -75,13 +75,21 @@ export const useFormHandle = <Values extends object, Err>(
   useSubscription(stateAtom);
 
   return {
-    isSubmitting: stateAtom.val.isSubmitting,
+    get isSubmitting() {
+      return stateAtom.val.isSubmitting;
+    },
 
-    isTouched: stateAtom.val.isTouched,
+    get isTouched() {
+      return stateAtom.val.isTouched;
+    },
 
-    isValid: stateAtom.val.isValid,
+    get isValid() {
+      return stateAtom.val.isValid;
+    },
 
-    isValidating: stateAtom.val.isValidating,
+    get isValidating() {
+      return stateAtom.val.isValidating;
+    },
 
     get submitCount() {
       const { successfulSubmitCount, failedSubmitCount } = stateAtom.val;


### PR DESCRIPTION
Replaced `useFormHandle` return object fields with getters.

Fixes bug where after sync validation new `isValid` value is updated only on next render cycle, eg:
```tsx
const form = useFormHandle()

const handleClick = () => {
  form.validate() // sync validation performed
  
  if(form.isValid) { ... } // `isValid` still holds prev value, next value would be available in next render cycle
}
```